### PR TITLE
Update WRF_Hydro_Regridding_Spatial_Weights.py

### DIFF
--- a/wrfhydro_gis/WRF_Hydro_Regridding_Spatial_Weights.py
+++ b/wrfhydro_gis/WRF_Hydro_Regridding_Spatial_Weights.py
@@ -362,6 +362,7 @@ def Read_GEOGRID_for_SRS_old(in_nc, Variable):
         # Set the origin for the output raster (in GDAL, usuall upper left corner) using projected corner coordinates
         wgs84_proj = osr.SpatialReference()
         wgs84_proj.ImportFromEPSG(4326)
+        wgs84_proj.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         transform = osr.CoordinateTransformation(wgs84_proj, proj1)
         point = ogr.Geometry(ogr.wkbPoint)
         point.AddPoint_2D(lon, lat)
@@ -482,6 +483,7 @@ def Read_GEOGRID_for_SRS(in_nc):
     # Set the origin for the output raster (in GDAL, usuall upper left corner) using projected corner coordinates
     wgs84_proj = osr.SpatialReference()
     wgs84_proj.ImportFromEPSG(4326)
+    wgs84_proj.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
     transform = osr.CoordinateTransformation(wgs84_proj, proj1)
     point = ogr.Geometry(ogr.wkbPoint)
     point.AddPoint_2D(corner_lon, corner_lat)
@@ -575,6 +577,7 @@ def create_polygons_from_info(gridder_obj, proj1, outputFile, outDriverName, tic
 
     point_ref=ogr.osr.SpatialReference()
     point_ref.ImportFromEPSG(4326)                                              # WGS84
+    point_ref.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
     #coordTrans2 = ogr.osr.CoordinateTransformation(proj1, point_ref)            # Create transformation for converting to WGS84
 
     # Pull info out of th gridder object in order to create a polygon


### PR DESCRIPTION
Applying fix needed since specified GDAL version in README is 3.6.3:

While running the WRF-Hydro ArcGIS regridding preprocessor script, I encountered the error "PROJ: lcc: Invalid latitude" when attempting to transform geographic coordinates using the Lambert Conformal Conic (LCC) projection. This was due to a change in axis order conventions introduced in GDAL 3.x and PROJ 6+, where EPSG:4326 (WGS84) now defaults to latitude–longitude order instead of the traditional GIS-friendly longitude–latitude. As a result, the script passed coordinates as (lon, lat), but PROJ interpreted the first value as latitude, leading to an out-of-range error. I resolved this by explicitly setting the axis mapping strategy to traditional GIS order using wgs84_proj.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)  after importing EPSG:4326 in the script. This ensured the coordinates were correctly interpreted and allowed the projection transformation to proceed without errors. 

For more, see:
https://groups.google.com/a/ucar.edu/g/wrf-hydro_users/c/zXjpiDQvXhs